### PR TITLE
fix deprecations and errors on julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+# matrix:
+#   allow_failures:
+#     - julia: nightly
 notifications:
   email: false
 after_success:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.7-alpha

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,46 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+# uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+# matrix:
+#  allow_failures:
+#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
 branches:
   only:
     - master
-    - /release-.*/
+
 notifications:
   - provider: Email
     on_build_success: false
     on_build_failure: false
     on_build_status_changed: false
+
 install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        $env:JULIA_URL,
         "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
 build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"TypedBools\"); Pkg.build(\"TypedBools\")"
+
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"TypedBools\")"
+- C:\projects\julia\bin\julia -e "Pkg.test(\"TypedBools\")"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,5 +5,5 @@ Documenter.deploydocs(
     target = "build",
     deps = nothing,
     make = nothing,
-    julia = "0.6"
+    julia = "0.7"
 )

--- a/src/TypedBools.jl
+++ b/src/TypedBools.jl
@@ -1,11 +1,11 @@
 module TypedBools
 
-import Base: convert, &, |, ifelse
+import Base: convert, &, |
 """
     abstract TypedBool
 
 There are two TypedBools: `True` and `False`. They can be converted to `Bool`s.
-Logical operations and ifelse are defined for them. Using TypedBools can lead to
+Logical operations are defined for them. Using TypedBools can lead to
 type stability in cases where constant propogation is not working for Bools.
 
 ```jldoctest
@@ -18,22 +18,17 @@ julia> Bool(True())
 true
 
 julia> True() & True() & False()
-TypedBools.False()
+False()
 
 julia> False() & False() & True()
-TypedBools.False()
+False()
 
 julia> True() | True() | False()
-TypedBools.True()
+True()
 
 julia> False() | False() | True()
-TypedBools.True()
+True()
 
-julia> ifelse(True(), 1, 0)
-1
-
-julia> ifelse(False(), 1, 0)
-0
 ```
 """
 abstract type TypedBool end
@@ -50,13 +45,13 @@ export typed
 Convert a Bool to a TypedBool
 
 ```jldoctest
-julia> using TypedBools, Base.Test
+julia> using TypedBools, Test
 
 julia> typed(false)
-TypedBools.False()
+False()
 
 julia> typed(true)
-TypedBools.True()
+True()
 ```
 """
 typed(x) =
@@ -66,6 +61,8 @@ typed(x) =
         False()
     end
 
+Base.Bool(::True) = true
+Base.Bool(::False) = false
 Base.convert(::Type{Bool}, ::True) = true
 Base.convert(::Type{Bool}, ::False) = false
 
@@ -89,17 +86,14 @@ Negate a TypedBool
 julia> using TypedBools
 
 julia> not(True())
-TypedBools.False()
+False()
 
 julia> not(False())
-TypedBools.True()
+True()
 ```
 """
 not(::False) = True()
 not(::True) = False()
-
-ifelse(switch::False, new, old) = old
-ifelse(switch::True, new, old) = new
 
 export same_type
 """
@@ -111,10 +105,10 @@ Check whether `a` and `b` are the same type, return a typed bool.
 julia> using TypedBools
 
 julia> same_type(Val{:a}(), Val{:a}())
-TypedBools.True()
+True()
 
 julia> same_type(Val{:a}(), Val{:b}())
-TypedBools.False()
+False()
 ```
 """
 same_type(a::T, b::T) where T = True()


### PR DESCRIPTION
Happy Upgradathon Friday!

This PR fixes all test errors and deprecations on Julia v0.7. It also raises the minimum Julia version to v0.7-alpha. 

Unfortunately, I had to remove the `ifelse()` method, as it seems to be a built-in now and can't have methods added. 